### PR TITLE
Currency change in item chart

### DIFF
--- a/site/views/items-chart.js
+++ b/site/views/items-chart.js
@@ -141,7 +141,7 @@ class ItemsChart extends View {
                     return value.toLocaleString(navigator.language || "de-DE", {
                         minimumFractionDigits: 2,
                         style: "currency",
-                        currency: "EUR",
+                        currency: "CZK",
                     });
                 },
             },


### PR DESCRIPTION
It will change the currency from EUR to CZK in the item charts. With this change, the currency will correspond to the actual currency of Czech products.